### PR TITLE
Add tests to improve coverage of `get_params_dependent_on_targets`

### DIFF
--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -17,7 +17,8 @@ class GridDropout(DualTransform):
             Must be between 0 and 1. Default: 0.5.
         unit_size_min (int): minimum size of the grid unit. Must be between 2 and the image shorter edge.
             If 'None', holes_number_x and holes_number_y are used to setup the grid. Default: `None`.
-        unit_size_max (int): maximum size of the grid unit. Must be between 2 and the image shorter edge.
+        unit_size_max (int): maximum size of the grid unit. Must be between 2 and the image shorter edge, and
+            no lower than unit_size_min.
             If 'None', holes_number_x and holes_number_y are used to setup the grid. Default: `None`.
         holes_number_x (int): the number of grid units in x direction. Must be between 1 and image width//2.
             If 'None', grid unit width is set as image_width//10. Default: `None`.

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -699,6 +699,11 @@ def test_grid_dropout_params(ratio, holes_number_x, holes_number_y, unit_size_mi
         img = np.random.randint(0, 256, [256, 320], np.uint8)
         aug = A.GridDropout(p=1, mask_fill_value=0, holes_number_x=256)
         aug.get_params_dependent_on_targets({"image": img})
+    # with invalid holes_number_y (too small)
+    with pytest.raises(ValueError, match="hole_number_y must be between"):
+        img = np.random.randint(0, 256, [256, 320], np.uint8)
+        aug = A.GridDropout(p=1, mask_fill_value=0, holes_number_y=0)
+        aug.get_params_dependent_on_targets({"image": img})
 
 
 def test_gauss_noise_incorrect_var_limit_type():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -694,6 +694,11 @@ def test_grid_dropout_params(ratio, holes_number_x, holes_number_y, unit_size_mi
         img = np.random.randint(0, 256, [256, 320], np.uint8)
         aug = A.GridDropout(p=1, mask_fill_value=0, unit_size_min=5, unit_size_max=3000)
         aug.get_params_dependent_on_targets({"image": img})
+    # with invalid holes_number_x (too large)
+    with pytest.raises(ValueError, match="hole_number_x must be between"):
+        img = np.random.randint(0, 256, [256, 320], np.uint8)
+        aug = A.GridDropout(p=1, mask_fill_value=0, holes_number_x=256)
+        aug.get_params_dependent_on_targets({"image": img})
 
 
 def test_gauss_noise_incorrect_var_limit_type():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -684,6 +684,11 @@ def test_grid_dropout_params(ratio, holes_number_x, holes_number_y, unit_size_mi
     elif holes_number_x and holes_number_y:
         assert (holes[0][2] - holes[0][0]) == max(1, int(ratio * 320 // holes_number_x))
         assert (holes[0][3] - holes[0][1]) == max(1, int(ratio * 256 // holes_number_y))
+    # with invalid unit sizes (in this case, max < min)
+    with pytest.raises(ValueError, match="at least 2 pixels"):
+        img = np.random.randint(0, 256, [256, 320], np.uint8)
+        aug = A.GridDropout(p=1, mask_fill_value=0, unit_size_min=5, unit_size_max=3)
+        aug.get_params_dependent_on_targets({"image": img})
 
 
 def test_gauss_noise_incorrect_var_limit_type():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -689,6 +689,11 @@ def test_grid_dropout_params(ratio, holes_number_x, holes_number_y, unit_size_mi
         img = np.random.randint(0, 256, [256, 320], np.uint8)
         aug = A.GridDropout(p=1, mask_fill_value=0, unit_size_min=5, unit_size_max=3)
         aug.get_params_dependent_on_targets({"image": img})
+    # with invalid unit sizes (in this case, max is too large)
+    with pytest.raises(ValueError, match="size limits must be within the shortest image edge"):
+        img = np.random.randint(0, 256, [256, 320], np.uint8)
+        aug = A.GridDropout(p=1, mask_fill_value=0, unit_size_min=5, unit_size_max=3000)
+        aug.get_params_dependent_on_targets({"image": img})
 
 
 def test_gauss_noise_incorrect_var_limit_type():


### PR DESCRIPTION
This adds multiple new tests to ensure that the correct errors are raised upon passing invalid parameters to the method `GridDropout.get_params_dependent_on_targets`.
Required for #5.